### PR TITLE
Use pip, avoid needing to use static files cache

### DIFF
--- a/docs/platforms.rst
+++ b/docs/platforms.rst
@@ -40,7 +40,9 @@ Notes:
 
 - We manage hostnames in nginx, because there may be multiple QA and live hostnames
   so don't use Django's ALLOWED_HOSTS.
-
+- Make use of pip and virtualenv
+- Avoid using CachedStaticFilesStorage, or generating CSS/JS automatically as this
+  breaks load balanced environments.
 
 Vumi
 ----


### PR DESCRIPTION
Bunch of sites generate CSS dynamically - the same CSS every time which makes no sense, but the CachedStaticFilesStorage breaks load balancing entirely, as well as this is insanely inefficient. 

Also, time to make buildout go away and drag some people kicking and screaming into the 21st century. 
